### PR TITLE
Nerf merchant

### DIFF
--- a/src/main/java/io/github/apace100/originsclasses/mixin/MerchantEntityMixin.java
+++ b/src/main/java/io/github/apace100/originsclasses/mixin/MerchantEntityMixin.java
@@ -33,7 +33,7 @@ public class MerchantEntityMixin {
 
     @Redirect(method = "trade", at = @At(value = "INVOKE", target = "Lnet/minecraft/village/TradeOffer;use()V"))
     private void dontUseUpTrades(TradeOffer tradeOffer) {
-        int rand_trade = random.nextInt(3);
+        int rand_trade = random.nextInt(4);
         if(((Object)this instanceof WanderingTraderEntity) || !ClassPowerTypes.TRADE_AVAILABILITY.isActive(this.customer)) {
             tradeOffer.use();
         } else {
@@ -41,9 +41,7 @@ public class MerchantEntityMixin {
                 case 0:
                 tradeOffer.use();
                     break;
-                case 1:
-                    break;
-                case 2:
+                default:
                     break;
             }
         }

--- a/src/main/java/io/github/apace100/originsclasses/mixin/MerchantEntityMixin.java
+++ b/src/main/java/io/github/apace100/originsclasses/mixin/MerchantEntityMixin.java
@@ -6,6 +6,7 @@ import net.minecraft.entity.passive.WanderingTraderEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
+import net.minecraft.tag.ItemTags;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.village.TradeOffer;
@@ -29,10 +30,22 @@ public class MerchantEntityMixin {
     private int offerCountWithoutAdditional;
     private TradeOfferList additionalOffers;
 
+
     @Redirect(method = "trade", at = @At(value = "INVOKE", target = "Lnet/minecraft/village/TradeOffer;use()V"))
     private void dontUseUpTrades(TradeOffer tradeOffer) {
+        int rand_trade = random.nextInt(3);
         if(((Object)this instanceof WanderingTraderEntity) || !ClassPowerTypes.TRADE_AVAILABILITY.isActive(this.customer)) {
             tradeOffer.use();
+        } else {
+            switch(rand_trade) {
+                case 0:
+                tradeOffer.use();
+                    break;
+                case 1:
+                    break;
+                case 2:
+                    break;
+            }
         }
     }
 
@@ -81,7 +94,7 @@ public class MerchantEntityMixin {
                 list.add(new TradeOffer(new ItemStack(Items.EMERALD, 21), new ItemStack(Items.DIAMOND, 3), 1, 5, 0.05F));
                 break;
             case 2:
-                list.add(new TradeOffer(new ItemStack(Items.PHANTOM_MEMBRANE, 5), new ItemStack(Items.EXPERIENCE_BOTTLE, 12), 1, 5, 0.05F));
+                list.add(new TradeOffer(new ItemStack(Items.EMERALD, 5), new ItemStack(Items.EXPERIENCE_BOTTLE, 12), 1, 5, 0.05F));
                 break;
             case 3:
                 list.add(new TradeOffer(new ItemStack(Items.EMERALD, 14), new ItemStack(Items.GOLDEN_APPLE), 2, 5, 0.05F));
@@ -89,8 +102,17 @@ public class MerchantEntityMixin {
             case 4:
                 list.add(new TradeOffer(new ItemStack(Items.EMERALD, 5), new ItemStack(Items.SPONGE), 3, 2, 0.05F));
                 break;
-            case 5: case 6: case 7: case 8:
-                list.add(new TradeOffer(new ItemStack(Items.EMERALD, 16), new ItemStack(Registry.ITEM.getRandom(random)), 1, 5, 0.05F));
+            case 5:
+                list.add(new TradeOffer(new ItemStack(Items.EMERALD, 5), new ItemStack(Items.SPORE_BLOSSOM), 10, 5, 0.05F));
+                break;
+            case 6:
+                list.add(new TradeOffer(new ItemStack(Items.EMERALD, 16), new ItemStack(Items.BIG_DRIPLEAF), 1, 5, 0.05F));
+                break;
+            case 7:
+                list.add(new TradeOffer(new ItemStack(Items.EMERALD, 16), new ItemStack(Items.SMALL_DRIPLEAF), 1, 5, 0.05F));
+                break;
+            case 8:
+                list.add(new TradeOffer(new ItemStack(Items.EMERALD, 1), new ItemStack(ItemTags.FLOWERS.getRandom(random)), 64, 5, 0.05F));
                 break;
         }
         return list;

--- a/src/main/java/io/github/apace100/originsclasses/mixin/SimpleMerchantMixin.java
+++ b/src/main/java/io/github/apace100/originsclasses/mixin/SimpleMerchantMixin.java
@@ -18,7 +18,7 @@ public class SimpleMerchantMixin {
 
     @Redirect(method = "trade", at = @At(value = "INVOKE", target = "Lnet/minecraft/village/TradeOffer;use()V"))
     private void preventUseClientSide(TradeOffer tradeOffer) {
-        int rand_trade = random.nextInt(3);
+        int rand_trade = random.nextInt(4);
         if(ModPacketsS2C.isWanderingTrader || !ClassPowerTypes.TRADE_AVAILABILITY.isActive(player)) {
             tradeOffer.use();
         } else {
@@ -26,9 +26,7 @@ public class SimpleMerchantMixin {
                 case 0:
                     tradeOffer.use();
                     break;
-                case 1:
-                    break;
-                case 2:
+                default:
                     break;
             }
         }

--- a/src/main/java/io/github/apace100/originsclasses/mixin/SimpleMerchantMixin.java
+++ b/src/main/java/io/github/apace100/originsclasses/mixin/SimpleMerchantMixin.java
@@ -18,8 +18,19 @@ public class SimpleMerchantMixin {
 
     @Redirect(method = "trade", at = @At(value = "INVOKE", target = "Lnet/minecraft/village/TradeOffer;use()V"))
     private void preventUseClientSide(TradeOffer tradeOffer) {
+        int rand_trade = random.nextInt(3);
         if(ModPacketsS2C.isWanderingTrader || !ClassPowerTypes.TRADE_AVAILABILITY.isActive(player)) {
             tradeOffer.use();
+        } else {
+            switch(r) {
+                case 0:
+                    tradeOffer.use();
+                    break;
+                case 1:
+                    break;
+                case 2:
+                    break;
+            }
         }
     }
 }


### PR DESCRIPTION
I'm currently running a modded SMP and I've noticed the merchant class is extremely overpowered. It could be used to obtain bedrock, dragon eggs, and more. This should fix that, as well slightly nerf the infinite trading thing (making it a less chance to use up a trade)

NOTE: Currently switching IDEs and my compiler is broken so I haven't checked if this will compile. Proceed with caution